### PR TITLE
Fix group by queries

### DIFF
--- a/src/expr.c
+++ b/src/expr.c
@@ -4450,12 +4450,7 @@ expr_code_doover:
       }
       pCol = &pAggInfo->aCol[pExpr->iAgg];
       if( !pAggInfo->directMode ){
-        #ifdef FREEBSD_KERNEL
-        printf("Warning: sqlite3ExprCodeTarget - This code should not be called! The function is not ready yet!\n");
-        //todo: STELIOS
-        #else
         return AggInfoColumnReg(pAggInfo, pExpr->iAgg);
-        #endif
       }else if( pAggInfo->useSortingIdx ){
         Table *pTab = pCol->pTab;
         sqlite3VdbeAddOp3(v, OP_Column, pAggInfo->sortingIdxPTab,
@@ -5066,12 +5061,7 @@ expr_code_doover:
       if( pAggInfo ){
         assert( pExpr->iAgg>=0 && pExpr->iAgg<pAggInfo->nColumn );
         if( !pAggInfo->directMode ){
-          #ifdef FREEBSD_KERNEL
-          //todo: STELIOS
-          printf("Warning: AggInfoColumnReg not implemented\n");
-          #else
           inReg = AggInfoColumnReg(pAggInfo, pExpr->iAgg);
-          #endif
           break;
         }
         if( pExpr->pAggInfo->useSortingIdx ){


### PR DESCRIPTION
Previously, queries with a group by could only return an aggregate in the select clause. This allows you to return other fields, e.g., 

```
../tools/osdb_query "select name, count(*) from procs group by name" 
```