### PR TITLE
BUGFIX: define default for fallthrough macro

### DIFF
--- a/src/sqliteInt.h
+++ b/src/sqliteInt.h
@@ -149,6 +149,8 @@
 # define deliberate_fall_through __attribute__((fallthrough));
 #elif defined(LINUX_KERNEL_BUILD)
 # define deliberate_fall_through fallthrough;
+#else
+# define deliberate_fall_through
 #endif
 
 /*


### PR DESCRIPTION
The deliberate_fall_through macro is defined to disable warnings about missing break statements within a switch.
In the freebsd kernel, the clang compiler will be used, so the macro will not be defined and SQLite will not compile.
Defining a default value for the macro.